### PR TITLE
use quotes for search words consisting of multiple words, normalize variable and function names, show ignored words

### DIFF
--- a/tipuesearch_lite.js
+++ b/tipuesearch_lite.js
@@ -110,7 +110,7 @@ window.onload = function execute(){
         searchWordList = tempSearchWord;
 
         // actual "search" if the search word list is long enough
-        if (searchWordList.join().length >= set.minimumLength) {
+        if (searchWordList.join().length + commonWordsFound.join().length >= set.minimumLength) {
             // loop over pages and search in text
             for (var i = 0; i < tipuesearch.pages.length; i++) {
                 var score = 0;
@@ -133,23 +133,25 @@ window.onload = function execute(){
             }
 
             // build search results HTML
+            if (set.showTitleCount) {
+                document.title = "(" + found.length + ") " + originalTitle;
+            }
+            if (found.length == 1) {
+                out += "<div id='tipue_search_results_count'>1 result";
+            } else {
+                out += "<div id='tipue_search_results_count'>" + found.length + " results";
+            }
+            // display search time
+            if (set.showTime) {
+                var endTimer = new Date().getTime();
+                var time = (endTimer - startTimer) / 1000;
+                out += " (" + time.toFixed(2) + " seconds)";
+            }
+            out += "</div>";
+            if (commonWordsFound.length > 0) {
+                out += "<div id='tipue_ignored_words'>Common words \"" + commonWordsFound.join(", ") + "\" got ignored.</div>";
+            }
             if (found.length != 0) {
-                if (set.showTitleCount) {
-                    document.title = "(" + found.length + ") " + originalTitle;
-                }
-                if (found.length == 1) {
-                    out += "<div id='tipue_search_results_count'>1 result";
-                } else {
-                    out += "<div id='tipue_search_results_count'>" + found.length + " results";
-                }
-                // display search time
-                if (set.showTime) {
-                    var endTimer = new Date().getTime();
-                    var time = (endTimer - startTimer) / 1000;
-                    out += " (" + time.toFixed(2) + " seconds)";
-                }
-                out += "</div>";
-
                 found.sort(function(a, b) {
                     return b.score - a.score
                 });
@@ -208,11 +210,7 @@ window.onload = function execute(){
                 out += "<div id='tipue_search_error'>Nothing found.</div>";
             }
         } else {
-            if (commonWordsFound.length > 0) {
-                out += "<div id='tipue_search_error'>Common words \"" + commonWordsFound.join(", ") + "\" got ignored.</div>";
-            } else {
-                out += "<div id='tipue_search_error'>Search should be " + set.minimumLength + " or more characters.</div>";
-            }
+            out += "<div id='tipue_search_error'>Search should be " + set.minimumLength + " or more characters.</div>";
         }
         // give the page the actual contents, which were build up
         document.getElementById("tipue_search_content").innerHTML = out;

--- a/tipuesearch_lite.js
+++ b/tipuesearch_lite.js
@@ -90,8 +90,6 @@ window.onload = function execute(){
     function getTipueSearch() {
         var startTimer = new Date().getTime();
         var out = "";
-        // inform if just common words like "and" are used in search (they are ignored)
-        var stopWordsFoundFlag = false;
         // save objects about pages that are found
         var found = [];
         // get and modify search words
@@ -101,15 +99,17 @@ window.onload = function execute(){
 
         // ignore stop words in search words
         var temp_searchWord = [];
+        var commonWordsFound = [];
         // for each word, check if it is stop word (common word)
         for (var i = 0; i < searchWordList.length; i++) {
             if (tipuesearch_stop_words.indexOf(searchWordList[i]) == -1) {
                 temp_searchWord.push(searchWordList[i]);
             } else {
-                stopWordsFoundFlag = true;
+                commonWordsFound.push(searchWordList[i]);
             }
         }
         searchWordList = temp_searchWord;
+
         // actual "search" if the search word list is long enough
         if (searchWordList.join().length >= set.minimumLength) {
             // loop over pages and search in text
@@ -209,8 +209,8 @@ window.onload = function execute(){
                 out += "<div id='tipue_search_error'>Nothing found.</div>";
             }
         } else {
-            if (stopWordsFoundFlag) { // for example if search is just "yourself"
-                out += "<div id='tipue_search_error'>Nothing found. Common words are largely ignored.</div>";
+            if (commonWordsFound.length > 0) {
+                out += "<div id='tipue_search_error'>Common words \"" + commonWordsFound.join(", ") + "\" got ignored.</div>";
             } else {
                 out += "<div id='tipue_search_error'>Search should be " + set.minimumLength + " or more characters.</div>";
             }

--- a/tipuesearch_lite.js
+++ b/tipuesearch_lite.js
@@ -5,7 +5,7 @@ Tipue Search Lite is released under the MIT License
 */
 
 // list from http://www.ranks.nl/stopwords
-var commonWords = ["a", "above", "after", "again", "against", "all", "am", "an", "and", "any", "are", "aren't", "as", "at", "be", "because", "been", "before", "being", "below", "between", "both", "but", "by", "can't", "cannot", "could", "couldn't", "did", "didn't", "do", "does", "doesn't", "doing", "don't", "down", "during", "each", "few", "for", "from", "further", "had", "hadn't", "has", "hasn't", "have", "haven't", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers", "herself", "him", "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm", "i've", "if", "in", "into", "is", "isn't", "it", "it's", "its", "itself", "let's", "me", "more", "most", "mustn't", "my", "myself", "no", "nor", "not", "of", "off", "on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out", "over", "own", "same", "shan't", "she", "she'd", "she'll", "she's", "should", "shouldn't", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs", "them", "themselves", "then", "there", "there's", "these", "they", "they'd", "they'll", "they're", "they've", "this", "those", "through", "to", "too", "under", "until", "up", "very", "was", "wasn't", "we", "we'd", "we'll", "we're", "we've", "were", "weren't", "what", "what's", "when", "when's", "where", "where's", "which", "while", "who", "who's", "whom", "why", "why's", "with", "won't", "would", "wouldn't", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself", "yourselves"];
+var commonWordList = ["a", "above", "after", "again", "against", "all", "am", "an", "and", "any", "are", "aren't", "as", "at", "be", "because", "been", "before", "being", "below", "between", "both", "but", "by", "can't", "cannot", "could", "couldn't", "did", "didn't", "do", "does", "doesn't", "doing", "don't", "down", "during", "each", "few", "for", "from", "further", "had", "hadn't", "has", "hasn't", "have", "haven't", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers", "herself", "him", "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm", "i've", "if", "in", "into", "is", "isn't", "it", "it's", "its", "itself", "let's", "me", "more", "most", "mustn't", "my", "myself", "no", "nor", "not", "of", "off", "on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out", "over", "own", "same", "shan't", "she", "she'd", "she'll", "she's", "should", "shouldn't", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs", "them", "themselves", "then", "there", "there's", "these", "they", "they'd", "they'll", "they're", "they've", "this", "those", "through", "to", "too", "under", "until", "up", "very", "was", "wasn't", "we", "we'd", "we'll", "we're", "we've", "were", "weren't", "what", "what's", "when", "when's", "where", "where's", "which", "while", "who", "who's", "whom", "why", "why's", "with", "won't", "would", "wouldn't", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself", "yourselves"];
 
 // Weighting for tipue KMP algorithm
 var tipuesearchWeight = {'weight': [
@@ -18,7 +18,6 @@ var tipuesearchWeight = {'weight': [
 
 function parseSearchWords(searchWord) {
     searchWord = searchWord.replace(/\+/g, " ").replace(/\s\s+/g, " ");
-
     var searchWordList = [];
     while (searchWord.length > 0) {
         searchWord = searchWord.trim();
@@ -98,19 +97,19 @@ window.onload = function execute(){
         var searchWordList = parseSearchWords(document.getElementById("tipue_search_input").value);
 
         // ignore common words in search
-        var tempSearchWord = [];
-        var commonWordsFound = [];
+        var tempSearchWordList = [];
+        var commonWordsFoundList = [];
         for (var i = 0; i < searchWordList.length; i++) {
-            if (commonWords.indexOf(searchWordList[i].toLowerCase()) == -1) {
-                tempSearchWord.push(searchWordList[i]);
+            if (commonWordList.indexOf(searchWordList[i].toLowerCase()) == -1) {
+                tempSearchWordList.push(searchWordList[i]);
             } else {
-                commonWordsFound.push(searchWordList[i]);
+                commonWordsFoundList.push(searchWordList[i]);
             }
         }
-        searchWordList = tempSearchWord;
+        searchWordList = tempSearchWordList;
 
         // actual "search" if the search word list is long enough
-        if (searchWordList.join().length + commonWordsFound.join().length >= set.minimumLength) {
+        if (searchWordList.join().length + commonWordsFoundList.join().length >= set.minimumLength) {
             // loop over pages and search in text
             for (var i = 0; i < tipuesearch.pages.length; i++) {
                 var score = 0;
@@ -148,8 +147,8 @@ window.onload = function execute(){
                 out += " (" + time.toFixed(2) + " seconds)";
             }
             out += "</div>";
-            if (commonWordsFound.length > 0) {
-                out += "<div id='tipue_ignored_words'>Common words \"" + commonWordsFound.join(", ") + "\" got ignored.</div>";
+            if (commonWordsFoundList.length > 0) {
+                out += "<div id='tipue_ignored_words'>Common words \"" + commonWordsFoundList.join(", ") + "\" got ignored.</div>";
             }
             if (found.length != 0) {
                 found.sort(function(a, b) {

--- a/tipuesearch_lite.js
+++ b/tipuesearch_lite.js
@@ -17,6 +17,8 @@ var tipuesearchWeight = {'weight': [
 
 
 function parseSearchWords(searchWord) {
+    searchWord = searchWord.replace(/\+/g, " ").replace(/\s\s+/g, " ");
+
     var searchWordList = [];
     while (searchWord.length > 0) {
         searchWord = searchWord.trim();
@@ -93,15 +95,13 @@ window.onload = function execute(){
         // save objects about pages that are found
         var found = [];
         // get and modify search words
-        var searchWordList = document.getElementById("tipue_search_input").value;
-        searchWordList = searchWordList.replace(/\+/g, " ").replace(/\s\s+/g, " ");
-        searchWordList = parseSearchWords(searchWordList.toLowerCase());
+        var searchWordList = parseSearchWords(document.getElementById("tipue_search_input").value);
 
         // ignore common words in search
         var tempSearchWord = [];
         var commonWordsFound = [];
         for (var i = 0; i < searchWordList.length; i++) {
-            if (commonWords.indexOf(searchWordList[i]) == -1) {
+            if (commonWords.indexOf(searchWordList[i].toLowerCase()) == -1) {
                 tempSearchWord.push(searchWordList[i]);
             } else {
                 commonWordsFound.push(searchWordList[i]);
@@ -267,23 +267,24 @@ window.onload = function execute(){
     function tipue_KMP(searchWordList, s_text, set, i) {
         var score = 0;
         for (var f = 0; f < searchWordList.length; f++) {
-            var pre_tab = KMP_prefix(searchWordList[f], searchWordList[f].length);
-            var match_cnt = KMP_search(searchWordList[f], pre_tab, tipuesearch.pages[i].title);
+            var searchWord = searchWordList[f].toLowerCase();
+            var pre_tab = KMP_prefix(searchWord, searchWord.length);
+            var match_cnt = KMP_search(searchWord, pre_tab, tipuesearch.pages[i].title);
             if (match_cnt != 0) {
                 score += (20 * match_cnt);
             }
-            match_cnt = KMP_search(searchWordList[f], pre_tab, s_text);
+            match_cnt = KMP_search(searchWord, pre_tab, s_text);
             if (match_cnt != 0) {
                 score += (20 * match_cnt);
             }
 
             if (tipuesearch.pages[i].tags) {
-                match_cnt = KMP_search(searchWordList[f], pre_tab, tipuesearch.pages[i].tags);
+                match_cnt = KMP_search(searchWord, pre_tab, tipuesearch.pages[i].tags);
                 if (match_cnt != 0) {
                     score += (10 * match_cnt);
                 }
             }
-            match_cnt = KMP_search(searchWordList[f], pre_tab, tipuesearch.pages[i].url);
+            match_cnt = KMP_search(searchWord, pre_tab, tipuesearch.pages[i].url);
             if (match_cnt != 0) {
                 score += 20;
             }
@@ -294,11 +295,11 @@ window.onload = function execute(){
                     }
                 }
             }
-            if (searchWordList[f].match("^-")) {
-                pat=new RegExp(searchWordList[f].substring(1),"i");
-                if (KMP_search(searchWordList[f], pre_tab, tipuesearch.pages[i].title) != 0 ||
-                    KMP_search(searchWordList[f], pre_tab, s_text) != 0 ||
-                    KMP_search(searchWordList[f], pre_tab, tipuesearch.pages[i].tags)!=0) {
+            if (searchWord.match("^-")) {
+                pat=new RegExp(searchWord.substring(1),"i");
+                if (KMP_search(searchWord, pre_tab, tipuesearch.pages[i].title) != 0 ||
+                    KMP_search(searchWord, pre_tab, s_text) != 0 ||
+                    KMP_search(searchWord, pre_tab, tipuesearch.pages[i].tags)!=0) {
                         score=0;
                 }
             }

--- a/tipuesearch_lite.js
+++ b/tipuesearch_lite.js
@@ -4,11 +4,11 @@ Copyright (c) 2019 Tipue
 Tipue Search Lite is released under the MIT License
 */
 
-//Stop words list from http://www.ranks.nl/stopwords
-var tipuesearch_stop_words = ["a", "above", "after", "again", "against", "all", "am", "an", "and", "any", "are", "aren't", "as", "at", "be", "because", "been", "before", "being", "below", "between", "both", "but", "by", "can't", "cannot", "could", "couldn't", "did", "didn't", "do", "does", "doesn't", "doing", "don't", "down", "during", "each", "few", "for", "from", "further", "had", "hadn't", "has", "hasn't", "have", "haven't", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers", "herself", "him", "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm", "i've", "if", "in", "into", "is", "isn't", "it", "it's", "its", "itself", "let's", "me", "more", "most", "mustn't", "my", "myself", "no", "nor", "not", "of", "off", "on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out", "over", "own", "same", "shan't", "she", "she'd", "she'll", "she's", "should", "shouldn't", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs", "them", "themselves", "then", "there", "there's", "these", "they", "they'd", "they'll", "they're", "they've", "this", "those", "through", "to", "too", "under", "until", "up", "very", "was", "wasn't", "we", "we'd", "we'll", "we're", "we've", "were", "weren't", "what", "what's", "when", "when's", "where", "where's", "which", "while", "who", "who's", "whom", "why", "why's", "with", "won't", "would", "wouldn't", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself", "yourselves"];
+// list from http://www.ranks.nl/stopwords
+var commonWords = ["a", "above", "after", "again", "against", "all", "am", "an", "and", "any", "are", "aren't", "as", "at", "be", "because", "been", "before", "being", "below", "between", "both", "but", "by", "can't", "cannot", "could", "couldn't", "did", "didn't", "do", "does", "doesn't", "doing", "don't", "down", "during", "each", "few", "for", "from", "further", "had", "hadn't", "has", "hasn't", "have", "haven't", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers", "herself", "him", "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm", "i've", "if", "in", "into", "is", "isn't", "it", "it's", "its", "itself", "let's", "me", "more", "most", "mustn't", "my", "myself", "no", "nor", "not", "of", "off", "on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out", "over", "own", "same", "shan't", "she", "she'd", "she'll", "she's", "should", "shouldn't", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs", "them", "themselves", "then", "there", "there's", "these", "they", "they'd", "they'll", "they're", "they've", "this", "those", "through", "to", "too", "under", "until", "up", "very", "was", "wasn't", "we", "we'd", "we'll", "we're", "we've", "were", "weren't", "what", "what's", "when", "when's", "where", "where's", "which", "while", "who", "who's", "whom", "why", "why's", "with", "won't", "would", "wouldn't", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself", "yourselves"];
 
 // Weighting for tipue KMP algorithm
-var tipuesearch_weight = {'weight': [
+var tipuesearchWeight = {'weight': [
     {'url': 'http://www.tipue.com', 'score': 60},
     {'url': 'http://www.tipue.com/search', 'score': 60},
     {'url': 'http://www.tipue.com/tipr', 'score': 30},
@@ -16,7 +16,7 @@ var tipuesearch_weight = {'weight': [
 ]};
 
 
-function parse_searchWords(searchWord) {
+function parseSearchWords(searchWord) {
     var searchWordList = [];
     while (searchWord.length > 0) {
         searchWord = searchWord.trim();
@@ -71,19 +71,19 @@ window.onload = function execute(){
     document.getElementById('tipue_search_input').form.onsubmit = function() {
         getTipueSearch();
 
-        var history_url = '';
-        var history_title = '';
+        var historyUrl = '';
+        var historyTitle = '';
 
         var term = document.getElementById("tipue_search_input").value;
         if (!term || term.length === 0) {
-            history_url = location.href.split('?')[0];
+            historyUrl = location.href.split('?')[0];
         } else {
-            history_url = history_url + '?q=' + term;
-            history_title = 'Search - ' + term;
+            historyUrl = historyUrl + '?q=' + term;
+            historyTitle = 'Search - ' + term;
         }
 
         // add to address bar and history
-        history.pushState({}, history_title, history_url);
+        history.pushState({}, historyTitle, historyUrl);
         return false;
     }
 
@@ -95,20 +95,19 @@ window.onload = function execute(){
         // get and modify search words
         var searchWordList = document.getElementById("tipue_search_input").value;
         searchWordList = searchWordList.replace(/\+/g, " ").replace(/\s\s+/g, " ");
-        searchWordList = parse_searchWords(searchWordList.toLowerCase());
+        searchWordList = parseSearchWords(searchWordList.toLowerCase());
 
-        // ignore stop words in search words
-        var temp_searchWord = [];
+        // ignore common words in search
+        var tempSearchWord = [];
         var commonWordsFound = [];
-        // for each word, check if it is stop word (common word)
         for (var i = 0; i < searchWordList.length; i++) {
-            if (tipuesearch_stop_words.indexOf(searchWordList[i]) == -1) {
-                temp_searchWord.push(searchWordList[i]);
+            if (commonWords.indexOf(searchWordList[i]) == -1) {
+                tempSearchWord.push(searchWordList[i]);
             } else {
                 commonWordsFound.push(searchWordList[i]);
             }
         }
-        searchWordList = temp_searchWord;
+        searchWordList = tempSearchWord;
 
         // actual "search" if the search word list is long enough
         if (searchWordList.join().length >= set.minimumLength) {
@@ -291,9 +290,9 @@ window.onload = function execute(){
                 score += 20;
             }
             if (score != 0) {
-                for (var e = 0; e < tipuesearch_weight.weight.length; e++) {
-                    if (tipuesearch.pages[i].url == tipuesearch_weight.weight[e].url) {
-                        score += tipuesearch_weight.weight[e].score;
+                for (var e = 0; e < tipuesearchWeight.weight.length; e++) {
+                    if (tipuesearch.pages[i].url == tipuesearchWeight.weight[e].url) {
+                        score += tipuesearchWeight.weight[e].score;
                     }
                 }
             }

--- a/tipuesearch_lite.js
+++ b/tipuesearch_lite.js
@@ -15,6 +15,35 @@ var tipuesearch_weight = {'weight': [
     {'url': 'http://www.tipue.com/support', 'score': 20}
 ]};
 
+
+function parse_searchWords(searchWord) {
+    var searchWordList = [];
+    while (searchWord.length > 0) {
+        searchWord = searchWord.trim();
+        if (searchWord.charAt(0) == '"' && searchWord.indexOf('"', 1) != -1) {
+            end = searchWord.indexOf('"', 1);
+            searchWordList.push(searchWord.slice(1, end));
+            searchWord = searchWord.slice(end + 1)
+        } else if (searchWord.charAt(0) == "'" && searchWord.indexOf("'", 1) != -1) {
+            end = searchWord.indexOf("'", 1);
+            searchWordList.push(searchWord.slice(1, end));
+            searchWord = searchWord.slice(end + 1)
+        } else if (searchWord.indexOf(" ", 1) != -1) {
+            end = searchWord.indexOf(" ", 1);
+            searchWordList.push(searchWord.slice(0, end));
+            searchWord = searchWord.slice(end + 1)
+        } else {
+            searchWordList.push(searchWord);
+            searchWord = '';
+        }
+    }
+    while (searchWordList.indexOf("") != -1) {
+        searchWordList.splice(searchWordList.indexOf(""), 1);
+    }
+    return searchWordList;
+}
+
+
 window.onload = function execute(){
     var set = {
         "contextBuffer": 60,
@@ -65,28 +94,24 @@ window.onload = function execute(){
         var stopWordsFoundFlag = false;
         // save objects about pages that are found
         var found = [];
-        // get and modify search word
+        // get and modify search words
         var searchWordList = document.getElementById("tipue_search_input").value;
         searchWordList = searchWordList.replace(/\+/g, " ").replace(/\s\s+/g, " ");
-        searchWordList = searchWordList.trim();
-        searchWordList = searchWordList.toLowerCase();
-        searchWordList = searchWordList.split(" ");
+        searchWordList = parse_searchWords(searchWordList.toLowerCase());
 
         // ignore stop words in search words
-        var temp_searchWord = "";
+        var temp_searchWord = [];
         // for each word, check if it is stop word (common word)
         for (var i = 0; i < searchWordList.length; i++) {
             if (tipuesearch_stop_words.indexOf(searchWordList[i]) == -1) {
-                temp_searchWord += " " + searchWordList[i];
+                temp_searchWord.push(searchWordList[i]);
             } else {
                 stopWordsFoundFlag = true;
             }
         }
-        temp_searchWord = temp_searchWord.trim();
-        searchWordList = temp_searchWord.split(" ");
-
+        searchWordList = temp_searchWord;
         // actual "search" if the search word list is long enough
-        if (temp_searchWord.length >= set.minimumLength) {
+        if (searchWordList.join().length >= set.minimumLength) {
             // loop over pages and search in text
             for (var i = 0; i < tipuesearch.pages.length; i++) {
                 var score = 0;

--- a/tipuesearch_lite.js
+++ b/tipuesearch_lite.js
@@ -66,14 +66,14 @@ window.onload = function execute(){
         // save objects about pages that are found
         var found = [];
         // get and modify search word
-        var searchBoxInput = document.getElementById("tipue_search_input").value;
-        searchBoxInput = searchBoxInput.replace(/\+/g, " ").replace(/\s\s+/g, " ");
-        searchBoxInput = searchBoxInput.trim();
-        var temp_searchWord = searchBoxInput.toLowerCase();
-        var searchWordList = temp_searchWord.split(" ");
+        var searchWordList = document.getElementById("tipue_search_input").value;
+        searchWordList = searchWordList.replace(/\+/g, " ").replace(/\s\s+/g, " ");
+        searchWordList = searchWordList.trim();
+        searchWordList = searchWordList.toLowerCase();
+        searchWordList = searchWordList.split(" ");
 
         // ignore stop words in search words
-        temp_searchWord = "";
+        var temp_searchWord = "";
         // for each word, check if it is stop word (common word)
         for (var i = 0; i < searchWordList.length; i++) {
             if (tipuesearch_stop_words.indexOf(searchWordList[i]) == -1) {


### PR DESCRIPTION
1. Since removal of the flag checking for quotes in commit ade00c8 quotes got treated as literal characters. 
    This adds a function for using quotes to have a search word consisting of multiple words.
2. To prevent search words in quotes from being broken up at spaces, `temp_searchWord` is now an array
    to begin with.
3. Normalize variable and function names with camelCase.
4. Instead of a flag to tell that some words got ignored, now shows a list of ignored words.
5. Always shows list of ignored words, not just when no results are found.
6. Variable `searchBoxInput` was removed, since it function could be fulfilled by `searchWordList`