### PR TITLE
use for...of loop and remove another loop, make variables human readable, remove options, fix: highlight all search words in results

### DIFF
--- a/tipuesearch_lite.js
+++ b/tipuesearch_lite.js
@@ -71,12 +71,12 @@ window.onload = function execute(){
                 resultsHTML += "<div class='tipue_search_content_url'><a href='" + r.url + "'>" + r.url + "</a></div>";
             }
             // add and modify output (for example display search words in bold)
-            if (r.description) {
-                let pageText = r.description;
+            if (r.text) {
+                let pageText = r.text;
                 if (set.showContext) {
                     let posSearchTerm = -1
                     for (const term of searchTerms) {
-                        posSearchTerm = r.description.toLowerCase().indexOf(term);
+                        posSearchTerm = r.text.toLowerCase().indexOf(term);
                         if (posSearchTerm != -1) {
                             break;
                         }
@@ -143,19 +143,11 @@ window.onload = function execute(){
 
     function getSearchResults(searchTerms, tipueIndex) {
         let results = [];
-
         for (const page of tipueIndex.pages) {
-            let score = 0;
-            score = tipue_KMP(searchTerms, page);
-
+            let score = tipue_KMP(searchTerms, page);
             if (score != 0) {
-                results.push({
-                    "score": score,
-                    "title": page.title,
-                    "description": page.text,
-                    "url": page.url,
-                    "note": page.note
-                });
+                page.score = score;
+                results.push(page);
             }
         }
 


### PR DESCRIPTION
1. A for loop got replaced with a for...of loop.
    Another for loop got replaced with slice, instead of looping over a list of strings.
2. While building the html page, text gets highlighted/cut to show with the results.
    The variables in that loop were changed to more human readable ones.
    This part contained multiple temporary strings and integers to get a sub-string
    of the page-text, some of them got removed.
3. Instead of having options, does the following things always: 
      - highlight search terms in results
      - show number of results in tab name
4. highlights now all searched words, instead of just the first one
5. If a page with a searched word got found, a new object got created and the fields
    of page were re-assigned to it with additional field `score`. Now score gets added
    to the existing page-object and this gets pushed to the results.