### PR TITLE
Replace big search algorithm with simple text scoring algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Differences from Tipue Search 7.1
 * Removed "word replacement"
 * Removed "stemming replacement"
 * Removed pagination of results
+* Removed "tipuesearchWeights"
 * Linting and code simplification
 
 


### PR DESCRIPTION
Deletes the multiple functions that calculated a score for pages.
Instead uses a simpler function, that calculates a score for text in general,
which is based on number of search words in text, and their length. Deletes
tipuesearchWeights in the beginning, which was used only in the old algorithm.
Multiple variables in setting parameters (to control the selection of text
displayed with result) were reduced to just one for the length of result-text.
The new function is used for rating pages, page title, and the text displayed
with results.